### PR TITLE
Iterative instead of recursive implementation, @inline(__always) a few more functions

### DIFF
--- a/Sources/PriorityQueueModule/PriorityQueue.swift
+++ b/Sources/PriorityQueueModule/PriorityQueue.swift
@@ -146,6 +146,7 @@ public struct PriorityQueue<Element: Comparable> {
 
   // MARK: -
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUp(startingAt index: Int) {
     guard let parentIdx = _parentIndex(of: index) else {
@@ -178,13 +179,10 @@ public struct PriorityQueue<Element: Comparable> {
   internal mutating func _bubbleUpMin(startingAt index: Int) {
     var index = index
       
-    while true {
-      guard let grandparentIdx = _grandparentIndex(of: index) else { return }
-
-      if storage[index] < storage[grandparentIdx] {
-          _swapAt(index, grandparentIdx)
-          index = grandparentIdx
-      } else { return }
+    while let grandparentIdx = _grandparentIndex(of: index),
+          storage[index] < storage[grandparentIdx] {
+      _swapAt(index, grandparentIdx)
+      index = grandparentIdx
     }
   }
 
@@ -193,13 +191,10 @@ public struct PriorityQueue<Element: Comparable> {
   internal mutating func _bubbleUpMax(startingAt index: Int) {
     var index = index
       
-    while true {
-      guard let grandparentIdx = _grandparentIndex(of: index) else { return }
-
-      if storage[index] > storage[grandparentIdx] {
-        _swapAt(index, grandparentIdx)
-        index = grandparentIdx
-      } else { return }
+    while let grandparentIdx = _grandparentIndex(of: index),
+          storage[index] > storage[grandparentIdx] {
+      _swapAt(index, grandparentIdx)
+      index = grandparentIdx
     }
   }
 
@@ -242,29 +237,24 @@ public struct PriorityQueue<Element: Comparable> {
   internal mutating func _trickleDownMin(startingAt index: Int) {
     var index = index
 
-    while true {
-      guard let (smallestDescendantIdx, isChild) =
-              _indexOfLowestPriorityChildOrGrandchild(of: index)
-      else {
-        // We have no descendants -- no need to trickle down further
-        return
-      }
+    while let (smallestDescendantIdx, isChild) =
+          _indexOfLowestPriorityChildOrGrandchild(of: index) {
 
       if storage[smallestDescendantIdx] < storage[index] {
         _swapAt(smallestDescendantIdx, index)
-      }
 
-      if isChild {
-        return
-      }
-        
-      // Smallest is a grandchild
-      let parentIdx = _parentIndex(of: smallestDescendantIdx)!
-      if storage[smallestDescendantIdx] > storage[parentIdx] {
-        _swapAt(smallestDescendantIdx, parentIdx)
-      }
+        if isChild {
+          return
+        }
+          
+        // Smallest is a grandchild
+        let parentIdx = _parentIndex(of: smallestDescendantIdx)!
+        if storage[smallestDescendantIdx] > storage[parentIdx] {
+          _swapAt(smallestDescendantIdx, parentIdx)
+        }
 
-      index = smallestDescendantIdx
+        index = smallestDescendantIdx
+      } else { return }
     }
   }
 
@@ -273,29 +263,24 @@ public struct PriorityQueue<Element: Comparable> {
   internal mutating func _trickleDownMax(startingAt index: Int) {
     var index = index
       
-    while true {
-      guard let (largestDescendantIdx, isChild) =
-              _indexOfHighestPriorityChildOrGrandchild(of: index)
-      else {
-        // We have no descendants -- no need to trickle down further
-        return
-      }
+    while let (largestDescendantIdx, isChild) =
+          _indexOfHighestPriorityChildOrGrandchild(of: index) {
 
       if storage[largestDescendantIdx] > storage[index] {
         _swapAt(largestDescendantIdx, index)
-      }
         
-      if isChild {
-        return
-      }
+        if isChild {
+          return
+        }
 
-      // Largest is a grandchild
-      let parentIdx = _parentIndex(of: largestDescendantIdx)!
-      if storage[largestDescendantIdx] < storage[parentIdx] {
-        _swapAt(largestDescendantIdx, parentIdx)
-      }
+        // Largest is a grandchild
+        let parentIdx = _parentIndex(of: largestDescendantIdx)!
+        if storage[largestDescendantIdx] < storage[parentIdx] {
+          _swapAt(largestDescendantIdx, parentIdx)
+        }
 
-      index = largestDescendantIdx
+        index = largestDescendantIdx
+      } else { return }
     }
   }
   /// Returns the lowest priority child or grandchild of the element at the

--- a/Sources/PriorityQueueModule/PriorityQueue.swift
+++ b/Sources/PriorityQueueModule/PriorityQueue.swift
@@ -173,23 +173,33 @@ public struct PriorityQueue<Element: Comparable> {
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMin(startingAt index: Int) {
-    guard let grandparentIdx = _grandparentIndex(of: index) else { return }
+    var index = index
+      
+    while true {
+      guard let grandparentIdx = _grandparentIndex(of: index) else { return }
 
-    if storage[index] < storage[grandparentIdx] {
-      _swapAt(index, grandparentIdx)
-      _bubbleUpMin(startingAt: grandparentIdx)
+      if storage[index] < storage[grandparentIdx] {
+          _swapAt(index, grandparentIdx)
+          index = grandparentIdx
+      } else { return }
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _bubbleUpMax(startingAt index: Int) {
-    guard let grandparentIdx = _grandparentIndex(of: index) else { return }
+    var index = index
+      
+    while true {
+      guard let grandparentIdx = _grandparentIndex(of: index) else { return }
 
-    if storage[index] > storage[grandparentIdx] {
-      _swapAt(index, grandparentIdx)
-      _bubbleUpMax(startingAt: grandparentIdx)
+      if storage[index] > storage[grandparentIdx] {
+        _swapAt(index, grandparentIdx)
+        index = grandparentIdx
+      } else { return }
     }
   }
 
@@ -214,6 +224,7 @@ public struct PriorityQueue<Element: Comparable> {
 
   // MARK: -
 
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDown(startingAt index: Int) {
     // Figure out if `index` is on an even or odd level
@@ -225,63 +236,68 @@ public struct PriorityQueue<Element: Comparable> {
       _trickleDownMax(startingAt: index)
     }
   }
-
+ 
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMin(startingAt index: Int) {
-    guard let (smallestDescendantIdx, isChild) =
-            _indexOfLowestPriorityChildOrGrandchild(of: index)
-    else {
-      // We have no descendants -- no need to trickle down further
-      return
-    }
+    var index = index
 
-    if isChild {
+    while true {
+      guard let (smallestDescendantIdx, isChild) =
+              _indexOfLowestPriorityChildOrGrandchild(of: index)
+      else {
+        // We have no descendants -- no need to trickle down further
+        return
+      }
+
       if storage[smallestDescendantIdx] < storage[index] {
         _swapAt(smallestDescendantIdx, index)
       }
-    } else {
+
+      if isChild {
+        return
+      }
+        
       // Smallest is a grandchild
-      if storage[smallestDescendantIdx] < storage[index] {
-        _swapAt(smallestDescendantIdx, index)
-
-        let parentIdx = _parentIndex(of: smallestDescendantIdx)!
-        if storage[smallestDescendantIdx] > storage[parentIdx] {
-          _swapAt(smallestDescendantIdx, parentIdx)
-        }
-
-        _trickleDownMin(startingAt: smallestDescendantIdx)
+      let parentIdx = _parentIndex(of: smallestDescendantIdx)!
+      if storage[smallestDescendantIdx] > storage[parentIdx] {
+        _swapAt(smallestDescendantIdx, parentIdx)
       }
+
+      index = smallestDescendantIdx
     }
   }
 
+  @inline(__always)
   @inlinable
   internal mutating func _trickleDownMax(startingAt index: Int) {
-    guard let (largestDescendantIdx, isChild) =
-            _indexOfHighestPriorityChildOrGrandchild(of: index)
-    else {
-      // We have no descendants -- no need to trickle down further
-      return
-    }
+    var index = index
+      
+    while true {
+      guard let (largestDescendantIdx, isChild) =
+              _indexOfHighestPriorityChildOrGrandchild(of: index)
+      else {
+        // We have no descendants -- no need to trickle down further
+        return
+      }
 
-    if isChild {
       if storage[largestDescendantIdx] > storage[index] {
         _swapAt(largestDescendantIdx, index)
       }
-    } else {
+        
+      if isChild {
+        return
+      }
+
       // Largest is a grandchild
-      if storage[largestDescendantIdx] > storage[index] {
-        _swapAt(largestDescendantIdx, index)
-
-        let parentIdx = _parentIndex(of: largestDescendantIdx)!
-        if storage[largestDescendantIdx] < storage[parentIdx] {
-          _swapAt(largestDescendantIdx, parentIdx)
-        }
-
-        _trickleDownMax(startingAt: largestDescendantIdx)
+      let parentIdx = _parentIndex(of: largestDescendantIdx)!
+      if storage[largestDescendantIdx] < storage[parentIdx] {
+        _swapAt(largestDescendantIdx, parentIdx)
       }
+
+      index = largestDescendantIdx
     }
   }
-
   /// Returns the lowest priority child or grandchild of the element at the
   /// given index.
   ///
@@ -289,6 +305,7 @@ public struct PriorityQueue<Element: Comparable> {
   ///
   /// - parameter index: The index of the element whose descendants should be
   ///                    compared.
+  @inline(__always)
   @inlinable
   internal func _indexOfLowestPriorityChildOrGrandchild(
     of index: Int
@@ -342,6 +359,7 @@ public struct PriorityQueue<Element: Comparable> {
   ///
   /// - parameter index: The index of the item whose descendants should be
   ///                    compared.
+  @inline(__always)
   @inlinable
   internal func _indexOfHighestPriorityChildOrGrandchild(
     of index: Int


### PR DESCRIPTION

Experiement with iterative implementations for core functions plus some extra inlining, seems to give a fairly significant 15-20% improvement.

### Checklist
- [ ] I've read the [Contribution Guidelines](/README.md#contributing-to-swift-collections)
- [x ] My contributions are licensed under the [Swift license](/LICENSE.txt).
- [ x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (if appropriate).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x ] I've verified that my change does not break any existing tests or introduce unexplained benchmark regressions.
- [ ] I've updated the documentation if necessary.

Previous recursive implementation benchmark:

<img width="1280" alt="priorityqueue-recursive" src="https://user-images.githubusercontent.com/8501048/123064226-6095e900-d40e-11eb-9e27-5fafd28107a9.png">

Iterative implementation results:
<img width="1280" alt="priorityqueue-iterative" src="https://user-images.githubusercontent.com/8501048/123064285-6db2d800-d40e-11eb-8d6d-55e16b32dcb8.png">

